### PR TITLE
[Bug] Dolby Cinema 크롤링 실패 문제 해결

### DIFF
--- a/scripts/crawlers/dolbyCrawler.ts
+++ b/scripts/crawlers/dolbyCrawler.ts
@@ -157,7 +157,7 @@ class DolbyCrawler extends Crawler {
 
                 let timeTable: string = ""; // Dolby Cinema 상영 시간표 
                 theaterNm.each((i, e) => {
-                    if ($(e).text() == "Dolby Cinema [Laser]") {    // 상영관 이름 확인
+                    if ($(e).text().toUpperCase().includes("DOLBY CINEMA")) {    // 상영관 이름 확인
                         let movieNm: string = $(e).parents('.theater-list').find('.theater-tit > p > a').text().trim(); // Dolby Cinema관에서 상영하는 영화 이름
                         let play: cheerio.Cheerio = $(e).parents('.theater-type-box').find('.theater-time table.time-list-table > tbody > tr > td'); // 상영 시간 정보
                         let playDate: string | undefined = $(play).attr('play-de'); // 상영 날짜


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

- #6 


## ✅ 체크리스트

- [x] 🔀 PR 제목의 형식 맞추기 <!-- ex) [Feature] ㅇㅇ 기능 추가 -->
- [x] 💡 이슈 등록
- [x] 🏷️ 라벨 등록
- [x] 🧹 불필요한 코드 제거
- [x] 🧪 로컬 테스트 완료


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

> 메가박스에서 Dolby Cinema를 표시하는 명칭이 대소문자가 바뀐다거나, 일부 문자열이 추가되는 문제가 종종 발생했습니다.
> 스크래핑한 극장명을 대문자로 변환한 후에 `DOLBY CINEMA` 문자열이 포함되어 있는지 확인하는 로직으로 추후 비슷한 문제가 덜 발생하게 구성했습니다.


## 📸 스크린샷 (UI 변경 시 필수)
<!-- UI 변경이 포함된 경우 변경된 화면의 스크린샷을 추가해 주세요. -->


