### PR TITLE
[Bug] 당일이 1일인 경우 월 구간 불일치

### DIFF
--- a/scripts/crawlers/imaxCrawler.ts
+++ b/scripts/crawlers/imaxCrawler.ts
@@ -60,10 +60,10 @@ class ImaxCrawler extends Crawler {
                 const dayContainer = await page.waitForSelector('div.dayScroll_container__e9cLv');   // 날짜 렌더링 대기
                 const dayBtns = await dayContainer?.$$('div > div > div') || [];  // 날짜 버튼들
 
-                let isExistedTargetDate = false;
+                let isExistedTargetDate: boolean = false;
                 let cursorMonth: number = new Date().getMonth() + 1;    // 탐색 중인 월(Month)의 구간
                 const targetMonth: number = parseInt(this.date.substring(4, 6), 10);    // 원하는 날짜의 월(Month)
-                const targetDate = this.getTargetDate();    // 원하는 날짜
+                const targetDate: string = this.getTargetDate();    // 원하는 날짜
                 let hasPreviousMonth: boolean = false;   // 이전 월의 존재 여부
 
                 for (const dayBtn of dayBtns) {

--- a/scripts/crawlers/imaxCrawler.ts
+++ b/scripts/crawlers/imaxCrawler.ts
@@ -64,6 +64,7 @@ class ImaxCrawler extends Crawler {
                 let cursorMonth: number = new Date().getMonth() + 1;    // 탐색 중인 월(Month)의 구간
                 const targetMonth: number = parseInt(this.date.substring(4, 6), 10);    // 원하는 날짜의 월(Month)
                 const targetDate = this.getTargetDate();    // 원하는 날짜
+                let hasPreviousMonth: boolean = false;   // 이전 월의 존재 여부
 
                 for (const dayBtn of dayBtns) {
                     const button = await dayBtn.$('button');
@@ -82,10 +83,16 @@ class ImaxCrawler extends Crawler {
                     if (dayText.includes('.')) {
                         const [month, day]: string[] = dayText.split('.');
                         cursorMonth = parseInt(month, 10);
+                        hasPreviousMonth = true;
 
-                    } else if (dayText === "01") {
-                        // 2개월 이상 후에는 CGV에서 01로 표시됨
-                        cursorMonth += 1;
+                    } else if (dayText === '01') {
+                        // 당일 또는 2개월 이상 후에는 CGV에서 01로 표시됨
+
+                        // 이전 month가 존재할 때만, 다음 달로 넘어간 것으로 간주
+                        if (hasPreviousMonth) {
+                            cursorMonth += 1;
+                        }
+                        
                         dayText = `${cursorMonth}.1`;   // 형식 통일
                     }
                     


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- ex) #이슈번호[, #이슈번호] -->

- #18 


## ✅ 체크리스트

- [x] 🔀 PR 제목의 형식 맞추기 <!-- ex) [Feature] ㅇㅇ 기능 추가 -->
- [x] 💡 이슈 등록
- [x] 🏷️ 라벨 등록
- [x] 🧹 불필요한 코드 제거
- [x] 🧪 로컬 테스트 완료


## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해 주세요. (이미지 첨부 가능) -->

> 매달 1일에 대해서 "month.day" 형식의 날짜가 당일이되면 01로 변경되는 문제가 발생하여, 정상적으로 날짜를 찾을 수 있게 변경했습니다.


## 📸 스크린샷 (UI 변경 시 필수)
<!-- UI 변경이 포함된 경우 변경된 화면의 스크린샷을 추가해 주세요. -->



## 👀 리뷰어 가이드라인
<!-- 리뷰어가 중점적으로 확인해야 할 사항을 작성해 주세요. -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

> 

